### PR TITLE
feat: add target id border customization

### DIFF
--- a/customizations/disabled/target border.res
+++ b/customizations/disabled/target border.res
@@ -1,0 +1,17 @@
+"Resource/UI/TargetID.res"
+{
+  "TargetNameLabelBG"
+	{
+		"ControlName"		"EditablePanel"
+		"fieldName"			"TargetNameLabelBG"
+		"xpos"				"-1"
+		"ypos"				"25"
+		"zpos"				"1"
+		"wide"				"640"
+		"tall"				"20"
+		"visible"			"1"
+		"enabled"			"1"
+		"bgcolor_override"		"TransparentBlack"
+		"border"			"HUDPanelBorder"
+	}
+}

--- a/resource/ui/targetid.res
+++ b/resource/ui/targetid.res
@@ -1,2 +1,3 @@
 "#base" "../../customizations/streamermode/targetid.res"
+"#base" "../../customizations/enabled/target border.res"
 "#base" "targetid-base.res"


### PR DESCRIPTION
# What's changed?

This PR brings improvement to issue #17

- Add transparent background/borders to target players' names

![image](https://github.com/user-attachments/assets/b5d0300f-088c-4161-9718-cddb80e647ad)
